### PR TITLE
Add Multiple Animations

### DIFF
--- a/lua/weapons/weapon_lscs/sh_combo.lua
+++ b/lua/weapons/weapon_lscs/sh_combo.lua
@@ -226,7 +226,12 @@ function SWEP:DoCombo()
 		end
 	end
 
-	self:PlayAnimation( ComboObj.AttackAnim, ComboObj.AttackAnimStart )
+	if istable(ComboObj.AttackAnim) then
+        	local randomAttack = ComboObj.AttackAnim[math.random(1, #ComboObj.AttackAnim)]
+        	self:PlayAnimation( randomAttack, ComboObj.AttackAnimStart )
+    	else
+        	self:PlayAnimation( ComboObj.AttackAnim, ComboObj.AttackAnimStart )
+    	end
 
 	local Time = CurTime() + ComboObj.Delay + ComboObj.Duration + 0.1
 	self:SetNextPrimaryAttack( Time )


### PR DESCRIPTION
Adds an option for people to pass a table and obtain a random animation, or simply pass a single animation if desired.

Can't remember a more efficient way to do this other than pull a random value from the table within range.

A simple QoL rather than critical fix or anything else.