### PR TITLE
fix: #13 Force Power not working with underscores in id

### DIFF
--- a/lua/lscs/init.lua
+++ b/lua/lscs/init.lua
@@ -83,7 +83,7 @@ function LSCS:ClassToItem( class )
 
 	local words = string.Explode( "_", class )
 	local type = words[ 2 ]
-	local id = words[ 3 ]
+	local id = table.concat(words, "_", 3)
 
 	if type == "saberhilt" then
 		return LSCS.Hilt[ id ]


### PR DESCRIPTION
This should work for both ids with extra underscores in the and, as well as without.