### PR TITLE
Probably patch randomAttack

### DIFF
--- a/lua/weapons/weapon_lscs/sh_combo.lua
+++ b/lua/weapons/weapon_lscs/sh_combo.lua
@@ -227,7 +227,7 @@ function SWEP:DoCombo()
 	end
 
 	if istable(ComboObj.AttackAnim) then
-        	local randomAttack = ComboObj.AttackAnim[math.random(1, #ComboObj.AttackAnim)]
+        	local randomAttack = ComboObj.AttackAnim[math.Round(util.SharedRandom("randomAnimations", 1, #ComboObj.AttackAnim))]
         	self:PlayAnimation( randomAttack, ComboObj.AttackAnimStart )
     	else
         	self:PlayAnimation( ComboObj.AttackAnim, ComboObj.AttackAnimStart )


### PR DESCRIPTION
Now I haven't been able to see if this becomes out of sync because of rounding, but it shouldn't be. According to its page it's still not guaranteed these are in sync. The rounding is required to probably call upon the table. But either way the values should just be two types one is just an integer now but the same exact value without float.